### PR TITLE
trophies: fix broken URL to github.com/beego/beego

### DIFF
--- a/trophies.md
+++ b/trophies.md
@@ -105,7 +105,7 @@ It's virtually impossible to keep track of all contributions were made.
 1. {**[coreos/etcd](https://github.com/coreos/etcd)**} [etcdserver/api/v2discovery: simplify !(x == y) to x != y](https://github.com/coreos/etcd/pull/9969)
 1. {**[openshift/origin](https://github.com/openshift/origin)**} [build/controller/build: simplify bool exprs](https://github.com/openshift/origin/pull/20542)
 1. {**[google/go-cloud](https://github.com/google/go-cloud)**} [all: simplify and clarify some expressions](https://github.com/google/go-cloud/pull/260)
-1. {**[astaxie/beego](github.com/astaxie/beego)**} [all: simplify boolean expressions](https://github.com/astaxie/beego/pull/3523)
+1. {**[beego/beego](github.com/beego/beego)**} [all: simplify boolean expressions](https://github.com/beego/beego/pull/3523)
 1. {**[golang/dep](https://github.com/golang/dep)**} [gps: simplify boolean expression](https://github.com/golang/dep/pull/2027)
 
 ### [switchTrue](https://go-critic.github.io/overview.html#switchtrue)


### PR DESCRIPTION
https://github.com/astaxie/beego is a fork of https://github.com/beego/beego